### PR TITLE
Use datetime_start if set, else datetime.now()

### DIFF
--- a/optdash/server.py
+++ b/optdash/server.py
@@ -81,7 +81,7 @@ def create_request_handler_class(study_cache: StudyCache) -> type:
                                 }
                                 for study in sorted(
                                     studies, key=lambda s: (
-                                        s.datetime_start if s.datetime_start is None else datetime.now()
+                                        s.datetime_start if s.datetime_start is not None else datetime.now()
                                     )
                                 )
                             ]


### PR DESCRIPTION
Previous version was falling back to datetime.now() only when it was set, but with a mix missing and filled datetime_starts, this can raise an error comparing NoneType and datetime