### PR TITLE
remove extra layer of encoding

### DIFF
--- a/optdash/frontend/src/utils/fetch-data.tsx
+++ b/optdash/frontend/src/utils/fetch-data.tsx
@@ -1,6 +1,6 @@
 function fetch_data(base_uri: string, query_params: string | string[][], data_setter: (x: any) => void, key: string = "") {
     let qs = new URLSearchParams(query_params);
-    let uri = encodeURI(base_uri + "?" + qs.toString());
+    let uri = base_uri + "?" + qs.toString();
     console.log("Fetching " + uri);
     fetch(uri)
         .then(res => res.json())


### PR DESCRIPTION
The querystring is already url encoded as part of toString so if the study name has special characters, they end up encoded twice between making it to the backend

```js
qs = new URLSearchParams([['a', 'b'], ['1=2', '3=4']])
// URLSearchParams {}

qs.toString()
// "a=b&1%3D2=3%3D4"

encodeURI(qs.toString())
// "a=b&1%253D2=3%253D4"
```