### PR TITLE
add _is_multi_objective attribute for optdash.study.Study

### DIFF
--- a/optdash/frontend/src/utils/fetch-data.tsx
+++ b/optdash/frontend/src/utils/fetch-data.tsx
@@ -1,6 +1,6 @@
 function fetch_data(base_uri: string, query_params: string | string[][], data_setter: (x: any) => void, key: string = "") {
     let qs = new URLSearchParams(query_params);
-    let uri = encodeURI(base_uri + "?" + qs.toString());
+    let uri = base_uri + "?" + qs.toString();
     console.log("Fetching " + uri);
     fetch(uri)
         .then(res => res.json())

--- a/optdash/server.py
+++ b/optdash/server.py
@@ -81,7 +81,7 @@ def create_request_handler_class(study_cache: StudyCache) -> type:
                                 }
                                 for study in sorted(
                                     studies, key=lambda s: (
-                                        s.datetime_start if s.datetime_start is None else datetime.now()
+                                        s.datetime_start if s.datetime_start is not None else datetime.now()
                                     )
                                 )
                             ]

--- a/optdash/study.py
+++ b/optdash/study.py
@@ -15,6 +15,7 @@ class Study:
         self.best_trial = study.best_trial
         self.best_params = study.best_params
         self.best_value = study.best_value
+        self._is_multi_objective = study._is_multi_objective
         self.trials = study.get_trials(deepcopy=False)
 
     def get_trials(self, deepcopy: bool = True) -> List[optuna.trial.FrozenTrial]:


### PR DESCRIPTION
this fixes a bug in the Param Importance dashboard, otherwise an error is thrown by optuna. This is called by  `optuna.importance.get_param_importances` in `optdash.plot_data.build_importance_plot_data`, where the default evaluator is `optuna.importance._fanova.FanovaImportanceEvaluator` and checks `_is_multi_objective` when calling `evaluate`.
